### PR TITLE
Extrapolate SSP predictions in metallicity in misc_io.compute_ML_SSPs…

### DIFF
--- a/pynmap/misc_io.py
+++ b/pynmap/misc_io.py
@@ -10,6 +10,7 @@ from numpy import float64 as floatF
 from numpy import float32 as floatsF
 
 from scipy.interpolate  import griddata as gdata
+from scipy.interpolate  import interp1d
 
 import astropy
 from astropy.table import Table
@@ -49,15 +50,15 @@ def read_ascii_files(filename):
             if data.shape[0] == 7:
                 print("Found 7 columns, will not read age and Z/H")
                 x, y, z, vx, vy, vz, mass = data
-                logage = np.zeros_like(mass)
+                age = np.zeros_like(mass)
                 ZH = np.zeros_like(mass)
             elif data.shape[0] == 8:
                 print("Found 8 columns, will not read Z/H")
-                x, y, z, vx, vy, vz, mass, logage = data
+                x, y, z, vx, vy, vz, mass, age = data
                 ZH = np.zeros_like(mass)
             elif data.shape[0] == 9:
                 print("Found 9 columns, will read all including age and Z/H")
-                x, y, z, vx, vy, vz, mass, logage, ZH = data
+                x, y, z, vx, vy, vz, mass, age, ZH = data
             else:
                 print("ERROR: the input file should at least "
                       "contain 7 columns or no more than 9")
@@ -67,8 +68,8 @@ def read_ascii_files(filename):
             vel = np.vstack((vx, vy, vz)).T
 
             # Going into linear age and MH
-            age = 10**(logage)
-            MH = np.log10(ZH) - np.log10(0.19)
+            # age = 10**(logage)
+            MH = np.log10(ZH)
 
             return pos, vel, mass, age, MH
 
@@ -225,8 +226,24 @@ def compute_ML_SSPs(mass, age=None, MH=None,
         
         # interpolate the SSP predictions, and extract the M/L 
         # for the given (`age`, `MH`) pairs
-        ML = gdata((mAges, mMetals), sspML, (age, MH), method='cubic') 
         
+        # since the simulations can produce higher [Z/H] then the isochrones
+        # can model, we need to extrapolate (resticted to 1D) the current
+        # [Z/H] predictions of the SSP library
+        extraM = np.arange(0.6, 1.4, 0.2)
+        exML = []
+        for ai, age in enumerate(np.unique(mAges)):
+            aw = np.where( mAges==age )[0]
+            MF = interp1d( mMetals[aw], sspML[aw], fill_value='extrapolate' )
+            exML += [MF(extraM)]
+        for i in range(extraM.size):
+            mAges = np.append( mAges, np.unique(mAges) )
+            mMetals = np.append( mMetals, np.ones(np.unique(mAges).size)*extraM[i] )
+        newML = np.empty( mAges.size )
+        newML[:lAges.size] = sspML
+        newML[lAges.size:] = np.array(exML).T.ravel()
+        ML = gdata((mAges, mMetals), newML, (age, MH), method='cubic')
+
         return ML
         
     else:

--- a/pynmap/moments.py
+++ b/pynmap/moments.py
@@ -196,13 +196,14 @@ def project_data(x, y, data, weights=None, lim=[-1,1,-1,1], nXY=10):
         nXY = np.zeros(2, dtype=np.int) + nXY
     elif np.size(nXY) != 2 :
         print("ERROR: dimension of n should be 1 or 2")
-        return 0,0,0,0,0
+        return 0,0,0,0 # expect 4 values returned
 
     if weights is None : weights = np.ones_like(x)
     binX = np.linspace(lim[0], lim[1], nXY[0]+1)
     binY = np.linspace(lim[2], lim[3], nXY[1]+1)
     mat_weight = np.histogram2d(x, y, [binX, binY], weights=weights)[0]
-    mat_wdata = np.histogram2d(x, y, [binX, binY], weights=weights * data)[0]
+    hmask = np.isfinite(data)
+    mat_wdata = np.histogram2d(x[hmask], y[hmask], [binX, binY], weights=weights[hmask] * data[hmask])[0]
 
     mask = (mat_weight != 0)
     mat_data = np.zeros_like(mat_weight)

--- a/pynmap/pynmap.py
+++ b/pynmap/pynmap.py
@@ -193,7 +193,7 @@ class snapshot(object):
         self._vel_orig = copy.copy(self.vel)
         # Compute the luminosity
         self.ML = compute_ML(self.mass, self.age, self.MH, recipe=self.MLrecipe)
-        self.flux = self.mass * self.ML
+        self.flux = self.mass / self.ML
 
         # mask
         self.mask = (self.mass == 0)


### PR DESCRIPTION
Changes:
- Since the metallicity values in the simulation can easily exceed the maximum metallicity from the SSP predictions, and there is no efficient 2D **extrapolator**, extrapolate in serial (for each age, extrapolate the row of metallicities). More broadly, there could be a solution to avoid extrapolation altogether.

- The age appears to be linear in the simulation file, as it goes all the way to 12 for some particles.

- It seems that if any particle has a NaN value in some parameter that is given to `numpy.histogram2d`, that entire bin becomes a NaN. This was producing that 'hole' in the M/L map. Therefore masked the NaNs for `numpy.histogram2d`

- Flipped the operation for the conversion from mass to light in `pynmap.read_snapshot`