### PR TITLE
Add missing package to seutp.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,5 @@ setup(name='pynmap',
       author_email='eric.emsellem@eso.org',
       maintainer='Eric Emsellem',
       url='http://',
-      packages=['pynmap'],
+      packages=['pynmap', 'pynmap.utils'],
      )


### PR DESCRIPTION
The `pynmap.utils` package was not being installed, resulting in errors when running the code from an installation rather than from the sources. In particular this import failed: https://github.com/emsellem/pynmap/blob/67a83857784bf9f3af33c75d23100e91264f3ba2/pynmap/fit_losvd.py#L7

Originally found by @cdplagos.